### PR TITLE
Fixed MeepMeep issue "EmptySequenceException"

### DIFF
--- a/core/src/main/kotlin/com/rowanmcalpin/nextftc/visualization/MeepMeepVisualizer.kt
+++ b/core/src/main/kotlin/com/rowanmcalpin/nextftc/visualization/MeepMeepVisualizer.kt
@@ -51,6 +51,7 @@ object MeepMeepVisualizer {
     }
 
     private fun routineToSegmentList(routine: CommandGroup): List<SequenceSegment> {
+        routine.onStart()
         val trajectories = arrayListOf<SequenceSegment>()
         for (command in routine.commands) {
             if (command is FollowTrajectory) {


### PR DESCRIPTION
Routine was not being "extracted" to have access to the contents inside

Fixed by adding `routine.onStart()`