### PR TITLE
handle nested sequentials/parallels and also sequential requirements

### DIFF
--- a/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
@@ -199,7 +199,7 @@ abstract class Command : Runnable {
      * Returns a [SequentialGroup] with this command and an arbitrary number of other commands
      * @param commands the other commands to create a [SequentialGroup] with
      */
-    fun then(vararg commands: Command) = SequentialGroup(
+    open fun then(vararg commands: Command) = SequentialGroup(
         this,
         *commands
     )
@@ -208,7 +208,7 @@ abstract class Command : Runnable {
      * Returns a [ParallelGroup] with this command and an arbitrary number of other commands
      * @param commands the other commands to create a [ParallelGroup] with
      */
-    fun and(vararg commands: Command) = ParallelGroup(
+    open fun and(vararg commands: Command) = ParallelGroup(
         this,
         *commands
     )

--- a/core/src/main/kotlin/dev/nextftc/core/commands/groups/ParallelGroup.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/groups/ParallelGroup.kt
@@ -23,7 +23,12 @@ import dev.nextftc.core.commands.Command
 /**
  * A [CommandGroup] that runs all of its children simultaneously.
  */
-open class ParallelGroup(vararg commands: Command) : CommandGroup(*commands) {
+open class ParallelGroup(vararg commands: Command) : CommandGroup(
+    *commands.flatMap { when(it) {
+    is ParallelGroup -> it.children
+    else -> listOf(it)
+} }.toTypedArray()
+) {
     init {
         named("ParallelGroup(${children.joinToString { it.name }})")
     }

--- a/core/src/main/kotlin/dev/nextftc/core/commands/groups/ParallelGroup.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/groups/ParallelGroup.kt
@@ -23,12 +23,7 @@ import dev.nextftc.core.commands.Command
 /**
  * A [CommandGroup] that runs all of its children simultaneously.
  */
-open class ParallelGroup(vararg commands: Command) : CommandGroup(
-    *commands.flatMap { when(it) {
-    is ParallelGroup -> it.children
-    else -> listOf(it)
-} }.toTypedArray()
-) {
+open class ParallelGroup(vararg commands: Command) : CommandGroup(*commands) {
     init {
         named("ParallelGroup(${children.joinToString { it.name }})")
     }
@@ -70,4 +65,7 @@ open class ParallelGroup(vararg commands: Command) : CommandGroup(
 
         super.stop(interrupted)
     }
+
+    override fun and(vararg commands: Command) =
+        ParallelGroup(*children.toTypedArray(), *commands)
 }

--- a/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
@@ -26,7 +26,6 @@ import dev.nextftc.core.commands.Command
 class SequentialGroup(vararg commands: Command) : CommandGroup(*commands) {
     init {
         named("SequentialGroup(${children.joinToString { it.name }})")
-        setRequirements(children.first().requirements)
     }
     /**
      * This returns true once all of its children have finished running.
@@ -54,7 +53,6 @@ class SequentialGroup(vararg commands: Command) : CommandGroup(*commands) {
         children.removeFirst().stop(false)
 
         if (children.isNotEmpty()) children.first().start()
-        setRequirements(children.first().requirements)
     }
 
     override fun stop(interrupted: Boolean) {

--- a/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
@@ -23,12 +23,7 @@ import dev.nextftc.core.commands.Command
 /**
  * A [CommandGroup] that runs its children one at a time.
  */
-class SequentialGroup(vararg commands: Command) : CommandGroup(
-    *commands.flatMap { when(it) {
-        is SequentialGroup -> it.children
-        else -> listOf(it)
-    } }.toTypedArray()
-) {
+class SequentialGroup(vararg commands: Command) : CommandGroup(*commands) {
     init {
         named("SequentialGroup(${children.joinToString { it.name }})")
         setRequirements(children.first().requirements)
@@ -67,4 +62,7 @@ class SequentialGroup(vararg commands: Command) : CommandGroup(
 
         super.stop(interrupted)
     }
+
+    override fun then(vararg commands: Command): SequentialGroup =
+        SequentialGroup(*children.toTypedArray(), *commands)
 }

--- a/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/groups/SequentialGroup.kt
@@ -23,9 +23,15 @@ import dev.nextftc.core.commands.Command
 /**
  * A [CommandGroup] that runs its children one at a time.
  */
-class SequentialGroup(vararg commands: Command) : CommandGroup(*commands) {
+class SequentialGroup(vararg commands: Command) : CommandGroup(
+    *commands.flatMap { when(it) {
+        is SequentialGroup -> it.children
+        else -> listOf(it)
+    } }.toTypedArray()
+) {
     init {
         named("SequentialGroup(${children.joinToString { it.name }})")
+        setRequirements(children.first().requirements)
     }
     /**
      * This returns true once all of its children have finished running.
@@ -53,6 +59,7 @@ class SequentialGroup(vararg commands: Command) : CommandGroup(*commands) {
         children.removeFirst().stop(false)
 
         if (children.isNotEmpty()) children.first().start()
+        setRequirements(children.first().requirements)
     }
 
     override fun stop(interrupted: Boolean) {


### PR DESCRIPTION
so now you won't have Sequential(Sequential(cmd1), cmd2) (same for Parallel), which makes `.then`/`.and` more tolerable

also changes sequentialgroup to only require the requirements of the currently active command

i also just wanted to say that i :heart: pedro