### PR TITLE
Bump Pedro Pathing Version + SDK Version to match Decode Season Release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,15 @@ agp = "8.7.3"
 kotlin = "1.9.0"
 
 commons-math3 = "3.6.1"
-pedro = "1.0.8"
-ftc = "10.1.1"
+pedro = "2.0.0"
+ftc = "11.0.0"
 dokka = "1.9.24"
 
 nextftc = "0.6.3"
 
 [libraries]
 commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
-pedro = { module = "com.pedropathing:pedro", version.ref = "pedro" }
+pedro = { module = "com.pedropathing:ftc", version.ref = "pedro" }
 ftc-robotcore = { group = "org.firstinspires.ftc", name="RobotCore", version.ref = "ftc" }
 ftc-hardware = { group = "org.firstinspires.ftc", name="Hardware", version.ref = "ftc" }
 

--- a/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/DisplacementDelay.kt
+++ b/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/DisplacementDelay.kt
@@ -1,7 +1,7 @@
 package com.rowanmcalpin.nextftc.pedro
 
-import com.pedropathing.localization.Pose
-import com.rowanmcalpin.nextftc.core.command.Command
+import com.pedropathing.geometry.Pose;
+import com.rowanmcalpin.nextftc.core.command.Command;
 
 /**
  * This is a delay that waits until the robot has been displaced (by driving) a certain distance.

--- a/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/DriverControlled.kt
+++ b/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/DriverControlled.kt
@@ -59,7 +59,7 @@ class DriverControlled @JvmOverloads constructor(val driveJoystick: Joystick, va
     }
     
     override fun update() {
-        PedroData.follower!!.setTeleOpMovementVectors(driveJoystick.y.toDouble() * if(invertDrive) -1 else 1,
+        PedroData.follower!!.setTeleOpDrive(driveJoystick.y.toDouble() * if(invertDrive) -1 else 1,
             driveJoystick.x.toDouble() * if(invertStrafe) -1 else 1, turnJoystick.x.toDouble() * if(invertTurn) -1 else 1, robotCentric)
     }
 }

--- a/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/FollowPath.kt
+++ b/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/FollowPath.kt
@@ -18,8 +18,8 @@ NextFTC: a user-friendly control library for FIRST Tech Challenge
 
 package com.rowanmcalpin.nextftc.pedro
 
-import com.pedropathing.pathgen.Path
-import com.pedropathing.pathgen.PathChain
+import com.pedropathing.paths.Path
+import com.pedropathing.paths.PathChain
 import com.rowanmcalpin.nextftc.core.Subsystem
 import com.rowanmcalpin.nextftc.core.command.Command
 import com.rowanmcalpin.nextftc.ftc.hardware.Drivetrain

--- a/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/PoseUtil.kt
+++ b/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/PoseUtil.kt
@@ -1,7 +1,7 @@
 @file:JvmName("PoseUtil")
 package com.rowanmcalpin.nextftc.pedro
 
-import com.pedropathing.localization.Pose
+import com.pedropathing.geometry.Pose
 import kotlin.math.pow
 import kotlin.math.sqrt
 

--- a/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/ProximityDelay.kt
+++ b/pedro/src/main/java/com/rowanmcalpin/nextftc/pedro/ProximityDelay.kt
@@ -1,6 +1,6 @@
 package com.rowanmcalpin.nextftc.pedro
 
-import com.pedropathing.localization.Pose
+import com.pedropathing.geometry.Pose
 import com.rowanmcalpin.nextftc.core.command.Command
 
 /**


### PR DESCRIPTION
Hello! 

The `v2.0.0` update to Pedro Pathing introduced breaking changes that prevented `FollowPath` from working. I bumped the dependency version to `v2.0.0` and updated the few broken imports that were moved around, so it should be working now. I'll keep this as a draft request until I can test it with a robot tomorrow, but it should probably fix the issue.

Thanks for maintaining this amazing package!