### PR TITLE
Correct direction for velocity and position when motors are reversed.

### DIFF
--- a/hardware/src/main/kotlin/dev/nextftc/hardware/impl/MotorEx.kt
+++ b/hardware/src/main/kotlin/dev/nextftc/hardware/impl/MotorEx.kt
@@ -53,7 +53,7 @@ class MotorEx @JvmOverloads constructor(cacheTolerance: Double, motorFactory: ()
      * Gives the unmodified raw tick value of the motor
      */
     val rawTicks: Double
-        get() = motor.currentPosition.toDouble()
+        get() = motor.currentPosition.toDouble() * direction
 
     private val offsetable = Offsetable { rawTicks }
 
@@ -84,7 +84,7 @@ class MotorEx @JvmOverloads constructor(cacheTolerance: Double, motorFactory: ()
      */
     // Cannot use delegation because that would create motor immediately on field initialization instead of it being lazy.
     override val velocity: Double
-        get() = motor.velocity
+        get() = motor.velocity * direction
 
     /**
      * Gets / sets the current power of the motor (automatically implements power caching)

--- a/hardware/src/main/kotlin/dev/nextftc/hardware/impl/MotorEx.kt
+++ b/hardware/src/main/kotlin/dev/nextftc/hardware/impl/MotorEx.kt
@@ -53,7 +53,7 @@ class MotorEx @JvmOverloads constructor(cacheTolerance: Double, motorFactory: ()
      * Gives the unmodified raw tick value of the motor
      */
     val rawTicks: Double
-        get() = motor.currentPosition.toDouble() * direction
+        get() = motor.currentPosition.toDouble()
 
     private val offsetable = Offsetable { rawTicks }
 


### PR DESCRIPTION
This pull request addresses an error with the current position and velocity counting the opposite of the motor direction when reversed.  The effect of this error prevents proper use of the NextControl Control System without manually negating the position/velocity when feeding back the KineticState.