### PR TITLE
fix: make LambdaCommand correctly add requirements

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.nextftc.control)
 
     testImplementation(kotlin("test"))
+    testImplementation(libs.kotest.kotest.assertions.core)
 }
 
 nextFTCPublishing {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,8 @@ description = "The base for NextFTC, a user-friendly library for FTC. Includes c
 dependencies {
     api(libs.nextftc.bindings)
     api(libs.nextftc.control)
+
+    testImplementation(kotlin("test"))
 }
 
 nextFTCPublishing {
@@ -20,4 +22,8 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjvm-default=all", "-Xconsistent-data-class-copy-visibility")
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/Command.kt
@@ -110,6 +110,12 @@ abstract class Command : Runnable {
 
     fun cancel() = CommandManager.cancelCommand(this)
 
+    /**
+     * Whether this command is currently scheduled.
+     */
+    @get:JvmName("isScheduled")
+    val isScheduled get() = CommandManager.isScheduled(this)
+
     // region Property Setters
 
     /**

--- a/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
@@ -190,6 +190,7 @@ object CommandManager : Component {
             when (it) {
                 is SubsystemGroup -> expandSubsystemGroup(it)
                 is Collection<*> -> expandRequirements(it)
+                is Array<*> -> expandRequirements(it.asList())
                 else -> setOf(it)
             }
         }.toSet()

--- a/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
@@ -110,6 +110,14 @@ object CommandManager : Component {
     }
 
     /**
+     * Returns whether a command is scheduled to run or is already running
+     * @param command the command being checked
+     */
+    fun isScheduled(command: Command): Boolean {
+        return command in runningCommands || command in commandsToSchedule
+    }
+
+    /**
      * Cancels every command in the commandsToCancel list.
      */
     fun cancelCommands() {

--- a/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/CommandManager.kt
@@ -114,7 +114,10 @@ object CommandManager : Component {
      * @param command the command being checked
      */
     fun isScheduled(command: Command): Boolean {
-        return command in runningCommands || command in commandsToSchedule
+        return command in runningCommands ||
+                command in commandsToSchedule ||
+                runningCommands.any { it is CommandGroup && command in it.children } ||
+                commandsToSchedule.any { it is CommandGroup && command in it.children }
     }
 
     /**

--- a/core/src/main/kotlin/dev/nextftc/core/commands/utility/LambdaCommand.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/utility/LambdaCommand.kt
@@ -68,7 +68,7 @@ open class LambdaCommand @JvmOverloads constructor(name: String = "LambdaCommand
      * Adds [requirements] to the requirements that the command implements
      */
     override fun requires(vararg requirements: Any) =
-        apply { super.requires(requirements) }
+        apply { super.requires(*requirements) }
 
     /**
      * Sets the requirements that the command implements

--- a/core/src/test/kotlin/dev/nextftc/core/command/CommandTestBase.kt
+++ b/core/src/test/kotlin/dev/nextftc/core/command/CommandTestBase.kt
@@ -1,0 +1,25 @@
+package dev.nextftc.core.command
+
+import dev.nextftc.core.commands.CommandManager
+import dev.nextftc.core.commands.utility.LambdaCommand
+import dev.nextftc.core.commands.utility.NullCommand
+import org.junit.jupiter.api.BeforeEach
+
+abstract class CommandTestBase {
+    @BeforeEach
+    fun setup() {
+        CommandManager.cancelAll()
+    }
+
+    fun CommandManager.run(times: Int) {
+        repeat(times) { run() }
+    }
+
+    fun CommandManager.runUntilEmpty() {
+        while (hasCommands()) {
+            run()
+        }
+    }
+}
+
+fun labelCommand(label: String) = LambdaCommand(label).setIsDone { false }

--- a/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
+++ b/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
@@ -41,4 +41,71 @@ class TestInterruption : CommandTestBase() {
         CommandManager.isScheduled(a) shouldBe false
         CommandManager.isScheduled(b) shouldBe true
     }
+
+    @Test
+    fun `test requirement collision, not interruptible`() {
+        val a = labelCommand("A").requires(A).setInterruptible(false)
+        val b = labelCommand("B").requires(A)
+
+        CommandManager.scheduleCommand(a)
+        CommandManager.run()
+
+        CommandManager.isScheduled(a) shouldBe true
+
+        CommandManager.scheduleCommand(b)
+        CommandManager.run()
+
+        CommandManager.isScheduled(a) shouldBe true
+        CommandManager.isScheduled(b) shouldBe false
+    }
+
+    @Test
+    fun `test requirements in groups, interruptible`() {
+        val a = labelCommand("A").requires(A)
+        val b = labelCommand("B").requires(B)
+        val ab = a.then(b).setInterruptible(true)
+
+        val c = labelCommand("C").requires(A)
+
+        CommandManager.scheduleCommand(ab)
+        CommandManager.run()
+
+        CommandManager.isScheduled(ab) shouldBe true
+        CommandManager.isScheduled(a) shouldBe true
+        CommandManager.isScheduled(b) shouldBe true
+        CommandManager.isScheduled(c) shouldBe false
+
+        CommandManager.scheduleCommand(c)
+        CommandManager.run()
+
+        CommandManager.isScheduled(ab) shouldBe false
+        CommandManager.isScheduled(a) shouldBe false
+        CommandManager.isScheduled(b) shouldBe false
+        CommandManager.isScheduled(c) shouldBe true
+    }
+
+    @Test
+    fun `test requirements in groups, not interruptible`() {
+        val a = labelCommand("A").requires(A)
+        val b = labelCommand("B").requires(B)
+        val ab = a.then(b).setInterruptible(false)
+
+        val c = labelCommand("C").requires(A)
+
+        CommandManager.scheduleCommand(ab)
+        CommandManager.run()
+
+        CommandManager.isScheduled(ab) shouldBe true
+        CommandManager.isScheduled(a) shouldBe true
+        CommandManager.isScheduled(b) shouldBe true
+        CommandManager.isScheduled(c) shouldBe false
+
+        CommandManager.scheduleCommand(c)
+        CommandManager.run()
+
+        CommandManager.isScheduled(ab) shouldBe true
+        CommandManager.isScheduled(a) shouldBe true
+        CommandManager.isScheduled(b) shouldBe true
+        CommandManager.isScheduled(c) shouldBe false
+    }
 }

--- a/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
+++ b/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
@@ -1,14 +1,16 @@
 package dev.nextftc.core.command
 import dev.nextftc.core.commands.CommandManager
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotHave
 import org.junit.jupiter.api.Disabled
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
-object A
-object B
-object C
+data object A
+data object B
+data object C
 
 class TestInterruption : CommandTestBase() {
     @Test

--- a/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
+++ b/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
@@ -1,0 +1,44 @@
+package dev.nextftc.core.command
+import dev.nextftc.core.commands.CommandManager
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotHave
+import org.junit.jupiter.api.Disabled
+import kotlin.test.Test
+
+object A
+object B
+object C
+
+class TestInterruption : CommandTestBase() {
+    @Test
+    fun `test no requirement collision`() {
+        val a = labelCommand("A").requires(A)
+        val b = labelCommand("B").requires(B)
+
+        CommandManager.scheduleCommand(a)
+        CommandManager.scheduleCommand(b)
+
+        CommandManager.isScheduled(a) shouldBe true
+        CommandManager.isScheduled(b) shouldBe true
+    }
+
+    @Test
+    @Disabled("doesnt work for some reason")
+    fun `test requirement collision, interruptible`() {
+        val a = labelCommand("A").requires(A).setInterruptible(true)
+        val b = labelCommand("B").requires(A)
+
+        CommandManager.scheduleCommand(a)
+        CommandManager.run()
+
+        CommandManager.isScheduled(a) shouldBe true
+
+        CommandManager.scheduleCommand(b)
+        CommandManager.run()
+
+        CommandManager.snapshot shouldBe listOf("A", "B")
+        CommandManager.isScheduled(a) shouldBe false
+        CommandManager.isScheduled(b) shouldBe true
+    }
+}

--- a/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
+++ b/core/src/test/kotlin/dev/nextftc/core/command/TestCommandStuffIdk.kt
@@ -24,7 +24,6 @@ class TestInterruption : CommandTestBase() {
     }
 
     @Test
-    @Disabled("doesnt work for some reason")
     fun `test requirement collision, interruptible`() {
         val a = labelCommand("A").requires(A).setInterruptible(true)
         val b = labelCommand("B").requires(A)
@@ -37,7 +36,6 @@ class TestInterruption : CommandTestBase() {
         CommandManager.scheduleCommand(b)
         CommandManager.run()
 
-        CommandManager.snapshot shouldBe listOf("A", "B")
         CommandManager.isScheduled(a) shouldBe false
         CommandManager.isScheduled(b) shouldBe true
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotestAssertionsCoreVersion = "6.0.3"
+kotest = "5.9.1"
 kotlin = "2.0.0"
 ftc = "11.0.0"
 
@@ -7,7 +7,7 @@ ftc = "11.0.0"
 ftc-robot-core = { group = "org.firstinspires.ftc", name = "RobotCore", version.ref = "ftc" }
 ftc-hardware = { group = "org.firstinspires.ftc", name = "Hardware", version.ref = "ftc" }
 ftc-common = { group = "org.firstinspires.ftc", name = "FtcCommon", version.ref = "ftc" }
-kotest-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestAssertionsCoreVersion" }
+kotest-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 nextftc-control = { group = "dev.nextftc", name = "control", version = "1.0.0" }
 nextftc-bindings = { group = "dev.nextftc", name = "bindings", version = "1.0.1" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+kotestAssertionsCoreVersion = "6.0.3"
 kotlin = "2.0.0"
 ftc = "11.0.0"
 
@@ -6,6 +7,7 @@ ftc = "11.0.0"
 ftc-robot-core = { group = "org.firstinspires.ftc", name = "RobotCore", version.ref = "ftc" }
 ftc-hardware = { group = "org.firstinspires.ftc", name = "Hardware", version.ref = "ftc" }
 ftc-common = { group = "org.firstinspires.ftc", name = "FtcCommon", version.ref = "ftc" }
+kotest-kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestAssertionsCoreVersion" }
 nextftc-control = { group = "dev.nextftc", name = "control", version = "1.0.0" }
 nextftc-bindings = { group = "dev.nextftc", name = "bindings", version = "1.0.1" }
 


### PR DESCRIPTION
this PR also adds `isScheduled` to `CommandManager` and `Command` itself, and a kotlin("test") aka JUnit + Kotest for testing stuff