### PR TITLE
Changed isDone parameter of SwitchCommand and IfElseCommand to update when accessed

### DIFF
--- a/core/src/main/kotlin/dev/nextftc/core/commands/conditionals/IfElseCommand.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/conditionals/IfElseCommand.kt
@@ -37,7 +37,7 @@ class IfElseCommand @JvmOverloads constructor(
 
     private lateinit var selectedCommand: Command
 
-    override val isDone: Boolean by selectedCommand::isDone
+    override val isDone: Boolean get() = selectedCommand.isDone
 
     override fun start() {
         selectedCommand = if (condition()) trueCommand else falseCommand

--- a/core/src/main/kotlin/dev/nextftc/core/commands/conditionals/SwitchCommand.kt
+++ b/core/src/main/kotlin/dev/nextftc/core/commands/conditionals/SwitchCommand.kt
@@ -37,7 +37,7 @@ class SwitchCommand<T> @JvmOverloads constructor(
 
     private lateinit var selectedCommand: Command
 
-    override val isDone: Boolean by selectedCommand::isDone
+    override val isDone: Boolean get() = selectedCommand.isDone
 
     override fun start() {
         selectedCommand = outcomes[value()] ?: default


### PR DESCRIPTION
Both of the commands did not work as the `isDone` variable immediately accessed the lateinit `selectedCommand` and would lead to a crash. This changes `isDone` to have a getter which means that it will only be accessed when the command is initialised and used.